### PR TITLE
Updated dependencies notation to be more compatible with old nodes

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,14 +22,11 @@
     }
   ],
   "main": "index.js",
-  "engines": {
-    "node": ">= 0.8.0"
-  },
   "scripts": {
     "test": "nodeunit test"
   },
   "devDependencies": {
-    "nodeunit": "^0.8.6"
+    "nodeunit": "~0.8.6"
   },
   "keywords": [
     "css",
@@ -38,8 +35,8 @@
     "postcss"
   ],
   "dependencies": {
-    "postcss": "^0.3.2",
-    "onecolor": "^2.4.0",
+    "postcss": "~0.3.2",
+    "onecolor": "~2.4.0",
     "minimist": "0.0.8"
   },
   "bin": {


### PR DESCRIPTION
- removed `engine` - it's really useless and not recommended
- replaced `^` with `~` - only third number of semver is allowed to change safely for automatic updates. `^` is not supported by older npm.

We now use `csswring` in [mincer](https://github.com/nodeca/mincer), and really need backward compatibility.
