### PR TITLE
Preserve  also source maps comments

### DIFF
--- a/lib/csswring.js
+++ b/lib/csswring.js
@@ -89,7 +89,7 @@ var _wringAtRule = function (atRule) {
 
 // Comment
 var _wringComment = function (comment) {
-  if (comment.text.indexOf('!') !== 0) {
+  if (comment.text.indexOf('!') !== 0 && comment.text.indexOf('#') !== 0) {
     comment.removeSelf();
 
     return;


### PR DESCRIPTION
For now csswring removes source maps comments :crying_cat_face:
I'm going to use it in https://github.com/princed/grunt-csswring.
