### PR TITLE
Implement `removeAllComments` interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,27 @@ QUICK USAGE
     });
     fs.writeFileSync('test.min.css', csswring.wring(css).css);
 
-If you want to preserve some CSS hacks, set `preserveHacks` property of
-this module to `true`.
+
+OPTIONS
+-------
+
+### `preserveHacks`
+
+By default, CSSWring removes all unknown portion of CSS declaration that
+includes some CSS hacks (e.g., underscore hacks and star hacks). If you want to
+preserve these hacks, set `preserveHacks` property of this module to `true`.
+
+    var csswring = require('csswring');
+    csswring.preserveHacks = true;
+
+
+### `removeAllComments`
+
+By default, CSSWring keeps a comment that start with `/*!`. If you want to
+remove all comments, set `removeAllComments` property of this module to `true`.
+
+    var csswring = require('csswring');
+    csswring.removeAllComments = true;
 
 
 CLI USAGE
@@ -44,10 +63,11 @@ This package also installs a command line interface.
       Minify CSS file. That's only.
     
     Options:
-          --sourcemap       Create source map file.
-          --preserve-hacks  Preserve some CSS hacks.
-      -h, --help            Show this message.
-      -v, --version         Print version information.
+          --sourcemap            Create source map file.
+          --preserve-hacks       Preserve some CSS hacks.
+          --remove-all-comments  Remove all comments.
+      -h, --help                 Show this message.
+      -v, --version              Print version information.
 
 
 LICENSE

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -20,10 +20,11 @@ var _showHelp = function () {
   console.log('  ' + pkg.description);
   console.log('');
   console.log('Options:');
-  console.log('      --sourcemap       Create source map file.');
-  console.log('      --preserve-hacks  Preserve some CSS hacks.');
-  console.log('  -h, --help            Show this message.');
-  console.log('  -v, --version         Print version information.');
+  console.log('      --sourcemap            Create source map file.');
+  console.log('      --preserve-hacks       Preserve some CSS hacks.');
+  console.log('      --remove-all-comments  Remove all comments.');
+  console.log('  -h, --help                 Show this message.');
+  console.log('  -v, --version              Print version information.');
 };
 
 exports.cli = function (args) {
@@ -37,6 +38,7 @@ exports.cli = function (args) {
     boolean: [
       'sourcemap',
       'preserve-hacks',
+      'remove-all-comments',
       'help',
       'version'
     ],
@@ -47,6 +49,7 @@ exports.cli = function (args) {
     default: {
       sourcemap: false,
       'preserve-hacks': false,
+      'remove-all-comments': false,
       help: false,
       version: false
     }
@@ -74,6 +77,10 @@ exports.cli = function (args) {
 
       if (argv['preserve-hacks']) {
         csswring.preserveHacks = true;
+      }
+
+      if (argv['remove-all-comments']) {
+        csswring.removeAllComments = true;
       }
 
       opts.from = argv._[0];

--- a/lib/csswring.js
+++ b/lib/csswring.js
@@ -91,8 +91,10 @@ var _wringAtRule = function (atRule) {
 };
 
 // Comment
+var _removeAllComments = false;
+
 var _wringComment = function (comment) {
-  if (comment.text.indexOf('!') !== 0 && comment.text.indexOf('#') !== 0) {
+  if ((_removeAllComments || comment.text.indexOf('!') !== 0) && comment.text.indexOf('#') !== 0) {
     comment.removeSelf();
 
     return;
@@ -104,6 +106,9 @@ var _wringComment = function (comment) {
 // Preserve CSS hacks
 csswring.preserveHacks = false;
 
+// Remove all comments
+csswring.removeAllComments = false;
+
 // PostCSS Processor
 csswring.processor = function (css) {
   _preserveHacks = csswring.preserveHacks;
@@ -111,6 +116,7 @@ csswring.processor = function (css) {
   css.eachRule(_wringRule);
   _metCharset = false;
   css.eachAtRule(_wringAtRule);
+  _removeAllComments = csswring.removeAllComments;
   css.eachComment(_wringComment);
   css.after = '';
 

--- a/test/csswring_test.js
+++ b/test/csswring_test.js
@@ -24,7 +24,7 @@ var loadExpected = function (name) {
 };
 
 exports.testPublicInterfaces = function (test) {
-  test.expect(4);
+  test.expect(5);
 
   input = '.foo{color:black}';
   expected = postcss.parse(input);
@@ -35,6 +35,7 @@ exports.testPublicInterfaces = function (test) {
     csswring.wring(input, opts).map,
     expected.toResult(opts).map
   );
+  opts.map = undefined;
 
   test.strictEqual(
     postcss().use(csswring.processor).process(input).css,
@@ -46,8 +47,16 @@ exports.testPublicInterfaces = function (test) {
   input = loadInput(testCase);
   expected = loadExpected(testCase);
   test.strictEqual(csswring.wring(input).css, expected);
-
   csswring.preserveHacks = false;
+
+  csswring.removeAllComments = true;
+  opts.map = true;
+  testCase = 'remove-all-comments';
+  input = loadInput(testCase);
+  expected = loadExpected(testCase);
+  test.strictEqual(csswring.wring(input, opts).css, expected);
+  csswring.removeAllComments = false;
+  opts.map = undefined;
 
   test.done();
 };

--- a/test/expected/remove-all-comments.css
+++ b/test/expected/remove-all-comments.css
@@ -1,0 +1,2 @@
+.foo{display:auto}
+/*# sourceMappingURL=to.css.map */

--- a/test/fixtures/remove-all-comments.css
+++ b/test/fixtures/remove-all-comments.css
@@ -1,0 +1,7 @@
+/*!
+ * This comment will be removed if set `removeAllComments` to `true`.
+ */
+.foo {
+  display: auto;
+}
+/*# sourceMappingURL=to.css.map */


### PR DESCRIPTION
If `removeAllComments` sets to `true`, all comments will be removed except for
Source Maps.
