### PR TITLE
Implement a new csswring instance based API with per-instance  options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,11 @@ such as [Autoprefixer][6].
     postcss().use(
       autoprefixer.postcss
     ).use(
-      csswring.processor
+      csswring.postcss
     ).process(css);
 
+`.postcss` was previously called `.processor`, for backwards compatibility
+that name can still be used.
 
 CLI USAGE
 ---------

--- a/lib/csswring.js
+++ b/lib/csswring.js
@@ -116,11 +116,11 @@ function CSSWring(opts) {
   this.removeAllComments = opts.removeAllComments || false;
 
   // Bind processor to this so it can be passed to postcss with context
-  this.processor = _bind(this, this.processor);
+  this.postcss = _bind(this, this.postcss);
 }
 
 // PostCSS Processor
-CSSWring.prototype.processor = function(css) {
+CSSWring.prototype.postcss = function(css) {
   css.eachDecl(_bind(this, _wringDecl));
   css.eachRule(_bind(this, _wringRule));
   this._metCharset = false;
@@ -132,7 +132,7 @@ CSSWring.prototype.processor = function(css) {
 };
 
 CSSWring.prototype.wring = function(css, opts) {
-  return postcss().use(this.processor).process(css, opts);
+  return postcss().use(this.postcss).process(css, opts);
 };
 
 function csswring(opts) {
@@ -144,8 +144,9 @@ function csswring(opts) {
 }
 
 // PostCSS Processor
-csswring.processor = function(css) {
-  return csswring().processor(css);
+csswring.processor =
+csswring.postcss = function(css) {
+  return csswring().postcss(css);
 };
 
 // Wring CSS codes

--- a/test/csswring_test.js
+++ b/test/csswring_test.js
@@ -24,7 +24,7 @@ var loadExpected = function (name) {
 };
 
 exports.testPublicInterfaces = function (test) {
-  test.expect(12);
+  test.expect(13);
 
   input = '.foo{color:black}';
   expected = postcss.parse(input);
@@ -42,15 +42,21 @@ exports.testPublicInterfaces = function (test) {
   );
   opts.map = undefined;
 
-  // csswring.processor
+  // csswring.postcss
+  test.strictEqual(
+    postcss().use(csswring.postcss).process(input).css,
+    expected.toString()
+  );
+
+  // csswring.processor alias
   test.strictEqual(
     postcss().use(csswring.processor).process(input).css,
     expected.toString()
   );
 
-  // csswring().processor
+  // csswring().postcss
   test.strictEqual(
-    postcss().use(csswring().processor).process(input).css,
+    postcss().use(csswring().postcss).process(input).css,
     expected.toString()
   );
 
@@ -78,10 +84,10 @@ exports.testPublicInterfaces = function (test) {
   // csswring(options).wring()
   test.strictEqual(csswring({preserveHacks: true}).wring(preserveHacksInput).css, preserveHacksExpected);
 
-  // csswring(options).processor
+  // csswring(options).postcss
   test.strictEqual(
     postcss()
-      .use(csswring({preserveHacks: true}).processor)
+      .use(csswring({preserveHacks: true}).postcss)
       .process(preserveHacksInput)
       .css,
     preserveHacksExpected
@@ -93,7 +99,7 @@ exports.testPublicInterfaces = function (test) {
 
   test.strictEqual(
     postcss()
-      .use(a.processor)
+      .use(a.postcss)
       .process(preserveHacksInput)
       .css,
     preserveHacksExpected
@@ -101,7 +107,7 @@ exports.testPublicInterfaces = function (test) {
 
   test.strictEqual(
     postcss()
-      .use(b.processor)
+      .use(b.postcss)
       .process(input)
       .css,
     expected.toString()


### PR DESCRIPTION
- `csswring({preserveHacks: true, removeAllComments: true}).wring(css, {map: true});`
- `postcss().use(csswring({preserveHacks: true, removeAllComments: true}).processor).process(css, {map: true});`
- `csswring.wring(css, opts);` now accepts `preserveHacks` and `removeAllComments` as options in addition to the postcss options.
