### PR TITLE
Wring whitespaces inside value

### DIFF
--- a/lib/csswring.js
+++ b/lib/csswring.js
@@ -44,6 +44,9 @@ var _wringDecl = function (decl) {
     value = value.replace(_reValueFloatWithZero, '$1.$2');
     value = value.replace(_reValueColorFunction, _toHex);
     value = value.replace(_reValueColorHex, _wringHex);
+    value = value.replace(/\s+/g, ' ');
+    value = value.replace(/([!\(,])\s/g, '$1');
+    value = value.replace(/\s([!\),])/g, '$1');
     decl.value = value;
   }
 };

--- a/test/csswring_test.js
+++ b/test/csswring_test.js
@@ -144,7 +144,7 @@ exports['Option: removeAllComments'] = function (test) {
 };
 
 exports['Real CSS'] = function (test) {
-  test.expect(8);
+  test.expect(9);
 
   [
     'simple',
@@ -154,7 +154,8 @@ exports['Real CSS'] = function (test) {
     'value',
     'issue3',
     'issue11',
-    'duplicate-decl'
+    'duplicate-decl',
+    'issue13'
   ].forEach(function (testCase) {
     input = loadInput(testCase);
     expected = loadExpected(testCase);

--- a/test/expected/issue13.css
+++ b/test/expected/issue13.css
@@ -1,0 +1,1 @@
+.foo{background-image:url("1.png"),url("2.png"),linear-gradient(to bottom,#000 0,#fff 100%)}@font-face{src:url("f.eot#a") format("embedded-opentype"),url("f.woff") format("woff"),url("f.ttf") format("truetype"),url("f.svg#b") format("svg")}

--- a/test/fixtures/issue13.css
+++ b/test/fixtures/issue13.css
@@ -1,0 +1,17 @@
+.foo {
+  background-image: url("1.png"),
+    url("2.png"),
+    linear-gradient(
+      to bottom,
+      #000   0%,
+      #fff 100%
+    )
+  ;
+}
+
+@font-face {
+  src: url("f.eot#a") format("embedded-opentype"),
+       url("f.woff") format("woff"),
+       url("f.ttf") format("truetype"),
+       url("f.svg#b") format("svg");
+}


### PR DESCRIPTION
This removes whitespaces:
- before and after `!` of `!important` flag
- before and after comma
- first and last of functions

Fixes #13
