### PR TITLE
Wring `@media` parameters

### DIFF
--- a/lib/csswring.js
+++ b/lib/csswring.js
@@ -94,10 +94,22 @@ var _wringAtRule = function (atRule) {
     this._metCharset = true;
   }
 
+  if (atRule.name === 'media') {
+    var params = atRule.params;
+    params = params.replace(/\s+/g, ' ');
+    params = params.replace(/\s*([():])\s*/g, '$1');
+    atRule.params = params;
+
+    if (params.indexOf('(') === 0) {
+      atRule.afterName = '';
+    }
+  }
+
   atRule.before = '';
   atRule.between = '';
   atRule.semicolon = '';
   atRule.after = '';
+  delete atRule._params;
 };
 
 // Comment

--- a/test/csswring_test.js
+++ b/test/csswring_test.js
@@ -148,7 +148,7 @@ exports['Option: removeAllComments'] = function (test) {
 };
 
 exports['Real CSS'] = function (test) {
-  test.expect(10);
+  test.expect(11);
 
   [
     'simple',
@@ -160,7 +160,8 @@ exports['Real CSS'] = function (test) {
     'issue11',
     'duplicate-decl',
     'issue13',
-    'issue17'
+    'issue17',
+    'at-media-params'
   ].forEach(function (testCase) {
     input = loadInput(testCase);
     expected = loadExpected(testCase);

--- a/test/expected/at-media-params.css
+++ b/test/expected/at-media-params.css
@@ -1,0 +1,1 @@
+@media(min-width:99px)and(max-width:999px){.at-media-params{display:auto}}

--- a/test/expected/simple.css
+++ b/test/expected/simple.css
@@ -1,3 +1,3 @@
 /*!
  * This comment will *NOT* strip.
- */@import url("/css/include.css");.foo,.bar,.baz{color:red;background-color:cyan}@media screen and (min-width: 769px){.foo{color:green;background-color:magenta}}
+ */@import url("/css/include.css");.foo,.bar,.baz{color:red;background-color:cyan}@media screen and(min-width:769px){.foo{color:green;background-color:magenta}}

--- a/test/fixtures/at-media-params.css
+++ b/test/fixtures/at-media-params.css
@@ -1,0 +1,6 @@
+@media /* foo */ (  min-width: 99px    ) and
+(	max-width:    999px  ) {
+  .at-media-params {
+    display: auto;
+  }
+}


### PR DESCRIPTION
Wring `@media` parameters to less white spaces.
