### PR TITLE
Normalize `decl.before` and `decl.between`

### DIFF
--- a/lib/csswring.js
+++ b/lib/csswring.js
@@ -142,16 +142,20 @@ var _wringValue = function (value) {
 var _wringDecl = function (decl) {
   delete decl._value;
 
-  if (decl.important) {
-    decl._important = '!important';
-  }
-
-  if (this.preserveHacks) {
+  if (this.preserveHacks && decl.before) {
     decl.before = decl.before.replace(/[;\s]/g, '');
-    decl.between = decl.between.replace(_reWhiteSpaces, '');
   } else {
     decl.before = '';
+  }
+
+  if (this.preserveHacks && decl.between) {
+    decl.between = decl.between.replace(_reWhiteSpaces, '');
+  } else {
     decl.between = ':';
+  }
+
+  if (decl.important) {
+    decl._important = '!important';
   }
 
   var prop = decl.prop;


### PR DESCRIPTION
`decl.before` and `decl.between` can be `undefined`.

Also can be `undefined` following properties:
- `comment.before`
- `decl.important`
- `rule.before`
- `rule.between`
- `rule.semicolon`
- `rule.after`
- `atRule.before`
- `atRule.afterName`
- `atRule.between`
- `atRule.semicolon`
- `atRule.after`

But these properties reset correctly.
