### PR TITLE
Keep quote type

### DIFF
--- a/lib/csswring.js
+++ b/lib/csswring.js
@@ -29,9 +29,10 @@ var _isNotIdentifier = function (str) {
 // Unquote font family name if possible
 var _unquoteFontFamily = function (family) {
   family = family.replace(_reQuotedString, '$2');
+  var quote = RegExp.$1 || '"';
 
   if (list.space(family).some(_isNotIdentifier)) {
-    family = '"' + family + '"';
+    family = quote + family + quote;
   }
 
   return family;
@@ -65,9 +66,10 @@ var _toShortestColor = function (m, leading, r1, r2, g1, g2, b1, b2) {
 // Unquote inside `url()` notation if possible
 var _unquoteUrl = function (m, leading, url) {
   url = url.replace(_reQuotedString, '$2');
+  var quote = RegExp.$1 || '"';
 
   if (!/^[\x21-\x7d]+$/.test(url)) {
-    url = '"' + url + '"';
+    url = quote + url + quote;
   }
 
   return leading + 'url(' + url + ')';
@@ -98,10 +100,21 @@ var _removeDefaultFontFaceDescriptor = function (decl, index) {
   }
 };
 
+// Quote `@import` URL
+var _quoteImportURL = function (m, quote, url) {
+  if (!quote) {
+    quote = '"';
+  }
+
+  return quote + url + quote;
+};
+
 // Quote `@namespace` URL
 var _quoteNamespaceURL = function (param, index, p) {
   if (param === p[p.length -1]) {
-    param = param.replace(_reQuotedString, '"$2"');
+    param = param.replace(_reQuotedString, '$2');
+    var quote = RegExp.$1 || '"';
+    param = quote + param + quote;
   }
 
   return param;
@@ -265,7 +278,7 @@ var _wringAtRule = function (atRule) {
 
   if (atRule.name === 'import') {
     params = params.replace(_reUrl, '$1$2');
-    params = params.replace(_reQuotedString, '"$2"');
+    params = params.replace(_reQuotedString, _quoteImportURL);
   }
 
   if (atRule.name === 'namespace') {
@@ -282,7 +295,8 @@ var _wringAtRule = function (atRule) {
   if (
     !atRule.params ||
     params.indexOf('(') === 0 ||
-    params.indexOf('"') === 0
+    params.indexOf('"') === 0 ||
+    params.indexOf('\'') === 0
   ) {
     atRule.afterName = '';
   }

--- a/test/expected/at-import-url.css
+++ b/test/expected/at-import-url.css
@@ -1,1 +1,1 @@
-@import"foo.css";@import"bar.css";@import"baz.css";@import"qux.css";@import"quux.css";@import"corge.css" print,screen and (min-width:999px)
+@import"foo.css";@import"bar.css";@import'baz.css';@import"qux.css";@import'quux.css';@import"corge.css" print,screen and (min-width:999px)

--- a/test/expected/at-namespace-url.css
+++ b/test/expected/at-namespace-url.css
@@ -1,1 +1,1 @@
-@namespace"foo.css";@namespace"bar.css";@namespace"baz.css";@namespace"qux.css";@namespace"quux.css";@namespace corge"corge.css"
+@namespace"foo.css";@namespace"bar.css";@namespace'baz.css';@namespace"qux.css";@namespace'quux.css';@namespace corge"corge.css"

--- a/test/expected/issue30.css
+++ b/test/expected/issue30.css
@@ -1,0 +1,1 @@
+.foo{background-image:url("data:image/svg+xml,<svg version='1.0'></svg>")}.bar{background-image:url('data:image/svg+xml,<svg version="1.0"></svg>')}

--- a/test/fixtures/issue30.css
+++ b/test/fixtures/issue30.css
@@ -1,0 +1,7 @@
+.foo {
+  background-image: url("data:image/svg+xml,<svg version='1.0'></svg>");
+}
+
+.bar {
+  background-image: url('data:image/svg+xml,<svg version="1.0"></svg>');
+}


### PR DESCRIPTION
The type of quotation mark is important in non-escaped URL and font family name. This should keep a original one.

This fixes #30.
