### PR TITLE
Fixing the bug with at-rule

### DIFF
--- a/lib/csswring.js
+++ b/lib/csswring.js
@@ -287,7 +287,7 @@ var wringAtRule = function (atRule) {
     return;
   }
 
-  var params = atRule.params;
+  var params = atRule.params || '';
   params = params.replace(reWhiteSpaces, ' ');
   params = params.replace(/([(),:])\s/g, '$1');
   params = params.replace(/\s([),:])/g, '$1');

--- a/test/fixtures/font-face.css
+++ b/test/fixtures/font-face.css
@@ -9,7 +9,7 @@
   font-feature-settings: normal;
 }
 
-@font-face {
+@font-face{
   font-family: "Bar";
   src: url("bar.woff") format("woff");
   unicode-range: U+000000-10FFFF;


### PR DESCRIPTION
This PR fixes the bug with no whitespace between at-rule without params and the following brace: `@font-face{`. The error was:

``` sh
TypeError: Cannot call method 'replace' of undefined
    at wringAtRule (/Users/kizu/Projects/node-csswring/lib/csswring.js:291:19)
    at /Users/kizu/Projects/node-csswring/node_modules/postcss/lib/container.js:374:30
    at /Users/kizu/Projects/node-csswring/node_modules/postcss/lib/container.js:110:26
    at Root.Container.each (/Users/kizu/Projects/node-csswring/node_modules/postcss/lib/container.js:88:20)
    at Root.Container.eachInside (/Users/kizu/Projects/node-csswring/node_modules/postcss/lib/container.js:109:21)
    at Root.Container.WithRules.constructor$0.eachAtRule (/Users/kizu/Projects/node-csswring/node_modules/postcss/lib/container.js:372:21)
    at CSSWring.postcss (/Users/kizu/Projects/node-csswring/lib/csswring.js:334:7)
    at PostCSS.process (/Users/kizu/Projects/node-csswring/node_modules/postcss/lib/postcss.js:35:28)
    at CSSWring.wring (/Users/kizu/Projects/node-csswring/lib/csswring.js:340:38)
    at Function.csswring.wring (/Users/kizu/Projects/node-csswring/lib/csswring.js:358:25)
```
