### PR TITLE
Unquote value part of attribute selector

### DIFF
--- a/lib/csswring.js
+++ b/lib/csswring.js
@@ -14,10 +14,10 @@ var reDecimalWithZeros = /(^|\s|\(|,)(-)?0*([1-9]\d*)?\.(\d*[1-9])0*/g;
 var reDeclInParentheses = /\(([-a-zA-Z]+):(([^()]*(\([^()]*\))?)*)\)/g;
 var reDescriptorFontFace = /^font-(style|stretch|variant|feature-settings)$/i;
 var reNumberLeadingZeros = /(^|\s|\(|,)0+([1-9]\d*(\.\d+)?)/g;
-var reNotIdentifier = /([\x21-\x2c\x2e\x2f\x3a-\x40\x5b-\x5e\x60\x7b-\x9f]|^([0-9]|-(-|[0-9])))/;
+var reNotIdentifier = /([\x20-\x2c\x2e\x2f\x3a-\x40\x5b-\x5e\x60\x7b-\x9f]|^([0-9]|-(-|[0-9])))/;
 var rePropertyMultipleValues = /^(margin|padding|border-(color|radius|spacing|style|width))$/i;
 var reQuotedString = /("|')?(.*)\1/;
-var reSelectorAtt = /\[\s*(.*?)(?:\s*([~|^$*]?=)\s*(.*?))?\s*\]/g;
+var reSelectorAtt = /\[\s*(.*?)(?:\s*([~|^$*]?=)\s*(.*))?\s*\]/g;
 var reSelectorFunctions = /:(lang|nth-(?:last-)?(?:child|of-type)|not)\((.*?[^\\])\)/gi;
 var reSelectorCombinators = /\s*(\\?[>+~])\s*/g;
 var reSupportsConjunctions = /\)(and|or)/g;
@@ -107,6 +107,27 @@ var wringValue = function (value) {
   return value;
 };
 
+// Unquote attribute selector if possible
+var unquoteAttributeSelector = function (m, att, con, val) {
+  if (!con) {
+    return '[' + att + ']';
+  }
+
+  if (!val) {
+    return '[' + att + con + ']';
+  }
+
+  val = val.trim();
+  val = val.replace(reQuotedString, '$2');
+  var quote = RegExp.$1 || '"';
+
+  if (isNotIdentifier(val)) {
+    val = quote + val + quote;
+  }
+
+  return '[' + att + con + val + ']';
+};
+
 // Remove white spaces from string
 var removeWhiteSpaces = function (string) {
   return string.replace(reWhiteSpaces, '');
@@ -115,7 +136,7 @@ var removeWhiteSpaces = function (string) {
 // Wring selector of ruleset
 var wringSelector = function (selector) {
   selector = selector.replace(reWhiteSpaces, ' ');
-  selector = selector.replace(reSelectorAtt, '[$1$2$3]');
+  selector = selector.replace(reSelectorAtt, unquoteAttributeSelector);
   selector = selector.replace(reSelectorFunctions, removeWhiteSpaces);
   selector = selector.replace(reSelectorCombinators, '$1');
 

--- a/test/expected/issue37.css
+++ b/test/expected/issue37.css
@@ -1,0 +1,1 @@
+.bar[att=bar],.baz[att="baz?"],.foo[att=foo],.qux[att="q u x"]{display:block}

--- a/test/expected/selector-att.css
+++ b/test/expected/selector-att.css
@@ -1,1 +1,1 @@
-[bar="bar"],[baz*="baz"],[foo],[quux|=qu\]ux],[qux~='qu]x']{display:block}
+[bar=bar],[baz*=baz],[foo],[quux|="qu\]ux"],[qux~='qu]x']{display:block}

--- a/test/fixtures/issue37.css
+++ b/test/fixtures/issue37.css
@@ -1,0 +1,6 @@
+.foo[att="foo"],
+.bar[att=bar],
+.baz[att="baz?"],
+.qux[att="q u x"] {
+  display: block;
+}


### PR DESCRIPTION
If a value part of attribute selector contains only identifiers, no need
to quote it.

This closes #37.
