### PR TITLE
Remove white spaces only from both ends of `:not()`

### DIFF
--- a/lib/csswring.js
+++ b/lib/csswring.js
@@ -18,7 +18,8 @@ var reNumberLeadingZeros = /(^|\s|\(|,)0+([1-9]\d*(\.\d+)?)/g;
 var rePropertyMultipleValues = /^(margin|padding|border-(color|radius|spacing|style|width))$/i;
 var reQuotedString = /("|')?(.*)\1/;
 var reSelectorAtt = /\[\s*(.*?)(?:\s*([~|^$*]?=)\s*(.*))?\s*\]/g;
-var reSelectorFunctions = /:(lang|nth-(?:last-)?(?:child|of-type)|not)\((.*?[^\\])\)/gi;
+var reSelectorFunctions = /:(lang|nth-(?:last-)?(?:child|of-type))\((.*?[^\\])\)/gi;
+var reSelectorNegationFunction = /:not\((([^()]*(\([^()]*\))?)*)\)/gi;
 var reSelectorCombinators = /\s*(\\?[>+~])\s*/g;
 var reSupportsConjunctions = /\)(and|or)/g;
 var reUnicodeRangeDefault = /u\+0{1,6}-10ffff/i;
@@ -157,11 +158,17 @@ var removeWhiteSpaces = function (string) {
   return string.replace(reWhiteSpaces, '');
 };
 
+// Remove white spaces from both ends of `:not()`
+var trimNegationFunction = function (m, not) {
+  return ':not(' + not.trim() + ')';
+};
+
 // Wring selector of ruleset
 var wringSelector = function (selector) {
   selector = selector.replace(reWhiteSpaces, ' ');
   selector = selector.replace(reSelectorAtt, unquoteAttributeSelector);
   selector = selector.replace(reSelectorFunctions, removeWhiteSpaces);
+  selector = selector.replace(reSelectorNegationFunction, trimNegationFunction);
   selector = selector.replace(reSelectorCombinators, '$1');
 
   return selector;

--- a/test/expected/selector-function.css
+++ b/test/expected/selector-function.css
@@ -1,1 +1,1 @@
-.foo:lang(ja-JP),.bar:nth-child(2n+1),.baz:nth-last-child(-1n-1),.qux:nth-of-type(odd),.quux:not(bar){display:block}
+.foo:lang(ja-JP),.bar:nth-child(2n+1),.baz:nth-last-child(-1n-1),.qux:nth-of-type(odd),.quux:not(bar),.corge:not([class^="corge corge-"]){display:block}

--- a/test/fixtures/selector-function.css
+++ b/test/fixtures/selector-function.css
@@ -2,6 +2,7 @@
 .bar:nth-child(2n + 1),
 .baz:nth-last-child(  -1n - 1),
 .qux:nth-of-type(odd  ),
-.quux:not(    bar   ) {
+.quux:not(    bar   ),
+.corge:not([class^="corge corge-"]) {
   display: block;
 }


### PR DESCRIPTION
Removing all white spaces from `:not()` is wrong. This should be trimmed only.

This fixes #41.
