### PR TITLE
Prepare to PostCSS v3

### DIFF
--- a/lib/csswring.js
+++ b/lib/csswring.js
@@ -372,7 +372,7 @@ var wringRule = function (rule) {
   rule.semicolon = false;
   rule.after = '';
 
-  if (rule.decls.length === 0 || rule.selector === '') {
+  if (rule.childs.length === 0 || rule.selector === '') {
     rule.removeSelf();
 
     return;
@@ -451,7 +451,7 @@ var wringAtRule = function (atRule) {
   }
 
   if (atRule.name === 'font-face') {
-    if (atRule.decls.filter(isRequiredFontFaceDescriptor).length < 2) {
+    if (atRule.childs.filter(isRequiredFontFaceDescriptor).length < 2) {
       atRule.removeSelf();
 
       return;
@@ -460,10 +460,7 @@ var wringAtRule = function (atRule) {
     atRule.each(removeDefaultFontFaceDescriptor);
   }
 
-  if (
-    (atRule.rules && atRule.rules.length === 0) ||
-    (atRule.decls && atRule.decls.length === 0)
-  ) {
+  if (atRule.childs && atRule.childs.length === 0) {
     atRule.removeSelf();
 
     return;

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "minimist": "^1.1.0",
     "onecolor": "^2.4.0",
-    "postcss": "^2.0.0"
+    "postcss": "^3.0.0"
   },
   "devDependencies": {
     "nodeunit": "^0.9.0"

--- a/test/csswring_test.js
+++ b/test/csswring_test.js
@@ -119,7 +119,7 @@ exports['Option: removeAllComments'] = function (test) {
   var input = '/*!comment*/.foo{display:block}\n/*# sourceMappingURL=to.css.map */';
   var expected = '.foo{display:block}\n/*# sourceMappingURL=to.css.map */';
   var opts= {
-    map: true
+    map: {inline: false}
   };
 
   test.notStrictEqual(

--- a/test/expected/at-import-url.css
+++ b/test/expected/at-import-url.css
@@ -1,1 +1,1 @@
-@import"foo.css";@import"bar.css";@import'baz.css';@import"qux.css";@import'quux.css';@import"corge.css"print,screen and (min-width:999px)
+@import"foo.css";@import"bar.css";@import'baz.css';@import"qux.css";@import'quux.css';@import"corge.css"print,screen and (min-width:999px);

--- a/test/expected/at-namespace-url.css
+++ b/test/expected/at-namespace-url.css
@@ -1,1 +1,1 @@
-@namespace"foo.css";@namespace"bar.css";@namespace'baz.css';@namespace"qux.css";@namespace'quux.css';@namespace corge"corge.css"
+@namespace"foo.css";@namespace"bar.css";@namespace'baz.css';@namespace"qux.css";@namespace'quux.css';@namespace corge"corge.css";


### PR DESCRIPTION
Some changes have to be done to match [PostCSS 3](https://github.com/postcss/postcss/releases/tag/3.0.0).

You have to review this PR, I'm not sure everything is OK.
For example, 2 tests failed if it misses a semicolon at the end and I don't know why. Plus sourcemaps creation has changed.

But it's a start...
