### PR TITLE
Read input from standard input in CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ This package also installs a command line interface.
           --remove-all-comments  Remove all comments.
       -h, --help                 Show this message.
       -v, --version              Print version information.
+    
+    Use a single dash for INPUT to read input from standard input.
 
 
 MINIFICATIONS

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -20,6 +20,24 @@ var _showHelp = function () {
   console.log('      --remove-all-comments  Remove all comments.');
   console.log('  -h, --help                 Show this message.');
   console.log('  -v, --version              Print version information.');
+  console.log('');
+  console.log('Use a single dash for INPUT to read input from standard input.');
+};
+
+var _wring = function (css, conf, opts) {
+  var wringed = csswring(conf).wring(css, opts);
+
+  if (!opts.to) {
+    process.stdout.write(wringed.css);
+
+    return;
+  }
+
+  fs.writeFileSync(opts.to, wringed.css);
+
+  if (wringed.map) {
+    fs.writeFileSync(opts.to + '.map', wringed.map);
+  }
 };
 
 exports.cli = function (args) {
@@ -89,18 +107,21 @@ exports.cli = function (args) {
         };
       }
 
-      var wringed = csswring(conf).wring(fs.readFileSync(opts.from, 'utf8'), opts);
+      var css = '';
 
-      if (!opts.to) {
-        process.stdout.write(wringed.css);
-
-        break;
-      }
-
-      fs.writeFileSync(opts.to, wringed.css);
-
-      if (wringed.map) {
-        fs.writeFileSync(opts.to + '.map', wringed.map);
+      if (opts.from !== '-') {
+        css = fs.readFileSync(opts.from, 'utf8');
+        _wring(css, conf, opts);
+      } else {
+        delete opts.from;
+        var stdin = process.openStdin();
+        stdin.setEncoding('utf-8');
+        stdin.on('data', function(chunk) {
+          css += chunk;
+        });
+        stdin.on('end', function() {
+          _wring(css, conf, opts);
+        });
       }
   }
 };


### PR DESCRIPTION
Use `-` for INPUT to read input CSS from standard input:

```
$ cat in.css | csswring -
$ csswring - <in.css
```

Support Source Maps:

```
$ cat in.css | csswring --sourcemap -
$ cat in.css | csswring --sourcemap - out.css
```
