### PR TITLE
fix duplicate checker

### DIFF
--- a/lib/csswring.js
+++ b/lib/csswring.js
@@ -226,13 +226,37 @@ var uniqueArray = function (array) {
 
 // Remove duplicate declaration
 var removeDuplicateDeclaration = function (decl, index) {
-  var d = decl.before + decl.prop + decl.between + decl.value;
+  var declaration    = decl.before + decl.prop + decl.between + decl.value;
+  var isDuplicate    = this.hasOwnProperty(declaration);
+  var duplicateIndex = this[declaration];
 
-  if (this.hasOwnProperty(d)) {
-    decl.parent.remove(this[d]);
+  // take note that this declaration was found at this index
+  this[declaration] = index;
+
+  if (!isDuplicate) { return; }
+
+  var indexToRemove = duplicateIndex;
+
+  // this._removals keeps track of data regarding removed declarations.
+  //
+  // Removing at duplicateIndex is not reliable since siblings indexes
+  // can change during an iteration of this function.
+  if (this.hasOwnProperty('_removals')) {
+    // if this index has been affected by a previous removal, subtract the
+    // number of removed declarations from the index
+    indexToRemove = duplicateIndex > this._removals.maxIndex ?
+      duplicateIndex - this._removals.count : duplicateIndex;
+    // increment removal data
+    this._removals.count    = this._removals.count + 1;
+    this._removals.maxIndex = this._removals.maxIndex + indexToRemove;
+  } else {
+    this._removals = {
+      count:    1,
+      maxIndex: duplicateIndex
+    };
   }
 
-  this[d] = index;
+  decl.parent.remove(indexToRemove);
 };
 
 // Check required `@font-face` descriptor or not

--- a/test/expected/duplicate-decl.css
+++ b/test/expected/duplicate-decl.css
@@ -1,1 +1,1 @@
-.duplicate-decl{color:white;color:black}
+.duplicate-decl-simple{color:black;color:white}.duplicate-decl-complex-1{color:white;padding:10px;margin:0;color:black}.duplicate-decl-complex-2{color:black;padding:10px;color:white;margin:0}

--- a/test/fixtures/duplicate-decl.css
+++ b/test/fixtures/duplicate-decl.css
@@ -1,5 +1,23 @@
-.duplicate-decl {
+.duplicate-decl-simple {
   color: black;
   color: white;
   color: black;
+  color: white;
+}
+.duplicate-decl-complex-1 {
+  color:   black;
+  color:   white;
+  padding: 10px;
+  color:   black;
+  color:   white;
+  padding: 10px;
+  margin:  0;
+  color:   black;
+}
+.duplicate-decl-complex-2 {
+  color:   black;
+  color:   white;
+  padding: 10px;
+  color:   white;
+  margin:  0;
 }


### PR DESCRIPTION
In the current version of CSSWring, the duplicate checker is broken.

Running CSS Wring on this selector

```css
.duplicate {
  padding-right: 15px;
  padding-left: 15px;
  padding-right: 15px;
  padding-left: 15px;
}
```

Returns the wrong declarations

```css
.duplicate{padding-left:15px;padding-left:15px}
```

The bug is that calling `decl.parent.remove(this[d])` shifts all the indexes for sibling declarations, making the next call to `decl.parent.remove(this[id])` prone to removing the wrong declaration