### PR TITLE
`::` to `:`

### DIFF
--- a/index.js
+++ b/index.js
@@ -217,6 +217,9 @@ var wringSelector = function (selector) {
   ).replace(
     re.selectorCombinators,
     "$1"
+  ).replace(
+    re.selectorPseudoElements,
+    "$1"
   );
 };
 

--- a/lib/regexp.js
+++ b/lib/regexp.js
@@ -49,6 +49,9 @@ module.exports = {
   // :not(a)
   selectorNegationFunction: /:not\((([^()]*(\([^()]*\))?)*)\)/gi,
 
+  // ::before, ::after, ::first-line, ::first-letter
+  selectorPseudoElements: /(:)\1(?=after|before|first-(letter|line))/g,
+
   // ;
   semicolons: /;/g,
 

--- a/test/expected/selector-pseudo-elements.css
+++ b/test/expected/selector-pseudo-elements.css
@@ -1,0 +1,1 @@
+.foo:before,.bar:first-line{color:black}

--- a/test/fixtures/selector-pseudo-elements.css
+++ b/test/fixtures/selector-pseudo-elements.css
@@ -1,0 +1,4 @@
+.foo::before,
+.bar::first-line {
+  color: black;
+}


### PR DESCRIPTION
Almost all browser can read:

- `:before`
- `:after`
- `:first-line`
- `:first-letter`
