### PR TITLE
Remove declaration with hacks by default

### DIFF
--- a/index.js
+++ b/index.js
@@ -325,12 +325,26 @@ var wringComment = function (removeAllComments, comment) {
 
 // Wring declaration
 var wringDecl = function (preserveHacks, decl) {
+  var before = decl.raws.before;
+  var between = decl.raws.between;
   var prop = decl.prop;
   var value = decl.value;
   var values;
 
-  if (preserveHacks && decl.raws.before) {
-    decl.raws.before = decl.raws.before.replace(
+  if (
+    !preserveHacks &&
+    (
+      (before && before.match(re.hackSignProp) !== null) ||
+      (between && between.match(re.hackPropComment) !== null)
+    )
+  ) {
+    decl.remove();
+
+    return;
+  }
+
+  if (preserveHacks && before) {
+    before = before.replace(
       re.semicolons,
       ""
     ).replace(
@@ -338,14 +352,18 @@ var wringDecl = function (preserveHacks, decl) {
       ""
     );
   } else {
-    decl.raws.before = "";
+    before = "";
   }
 
-  if (preserveHacks && decl.raws.between) {
-    decl.raws.between = decl.raws.between.replace(re.whiteSpaces, "");
+  decl.raws.before = before;
+
+  if (preserveHacks && between) {
+    between = between.replace(re.whiteSpaces, "");
   } else {
-    decl.raws.between = ":";
+    between = ":";
   }
+
+  decl.raws.between = between;
 
   if (decl.important) {
     decl.raws.important = "!important";

--- a/lib/regexp.js
+++ b/lib/regexp.js
@@ -26,6 +26,12 @@ re.descriptorFontFace = /^font-(style|stretch|variant|feature-settings)$/i,
 // \(, \)
 re.escapedBraces = /\\([()])/g,
 
+// /**/, /*\**/
+re.hackPropComment = /\/\*(\\\*)?\*\//,
+
+// -, _, !, $, &, *, (, ), =, %, +, @, ,\, ., /, `, [, ], #, ~, ?, :, <, >, |
+re.hackSignProp = /[-_!$&*()=%+@,./`\[\]#~?:<>|]$/,
+
 // 0
 re.number = /\d/,
 

--- a/test/csswring_test.js
+++ b/test/csswring_test.js
@@ -62,7 +62,7 @@ exports["Option: preserveHacks"] = function (test) {
     preserveHacks: true
   };
 
-  test.expect(3);
+  test.expect(4);
 
   test.notStrictEqual(
     csswring.wring(input).css,
@@ -75,8 +75,13 @@ exports["Option: preserveHacks"] = function (test) {
   );
 
   test.notStrictEqual(
+    postcss([csswring(opts)]).process(input).css,
+    postcss([csswring()]).process(input).css
+  );
+
+  test.strictEqual(
     postcss([csswring()]).process(input).css,
-    postcss([csswring(opts)]).process(input).css
+    ""
   );
 
   test.done();


### PR DESCRIPTION
A CSS declaration with hack is ignored by a browser. So, these
declarations should be removed completely by default.

    .foo {
      _color: red;
      color: green;
    }

Should be:

    .foo{color:green}

This fixes #63.