### PR TITLE
Support custom properties

### DIFF
--- a/lib/regexp.js
+++ b/lib/regexp.js
@@ -75,7 +75,7 @@ re.urlFunction = /(^|\s|\(|,)url\((.*?[^\\])\)(?=$|\s|\)|,)/gi,
 re.urlNeedQuote = /[\s()"']/,
 
 // -valid_prop-name
-re.validProp = /^-?[_a-z][_a-z0-9-]*$/i,
+re.validProp = /^-{0,2}[_a-z][_a-z0-9-]*$/i,
 
 //  , \t, \r, \n
 re.whiteSpaces = /\s+/g,

--- a/test/expected/issue66.css
+++ b/test/expected/issue66.css
@@ -1,0 +1,1 @@
+:root{--foo:red}.foo{--bar:green;color:var(--foo);background-color:var(--bar)}

--- a/test/fixtures/issue66.css
+++ b/test/fixtures/issue66.css
@@ -1,0 +1,9 @@
+:root {
+  --foo: red;
+}
+
+.foo {
+  --bar: green;
+  color: var(--foo);
+  background-color: var(--bar);
+}


### PR DESCRIPTION
This commit allows properties starts with `--` for CSS Custom
Properties.

This fixes #66.