### PR TITLE
Ignore var() function on unquoting

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,6 +57,11 @@ var canUnquote = function (str) {
 // Unquote font family name if possible
 var unquoteFontFamily = function (family) {
   var quote;
+
+  if (family.match(re.varFunction)) {
+    return family;
+  }
+
   family = family.replace(re.quotedString, "$2");
   quote = setQuote(RegExp.$1);
 

--- a/lib/regexp.js
+++ b/lib/regexp.js
@@ -77,6 +77,9 @@ re.urlNeedQuote = /[\s()"']/,
 // --valid_prop-name
 re.validProp = /^-{0,2}[^!-,./:-@[-^`{-~]+$/i,
 
+// var(--custom-prop-name)
+re.varFunction = /^var\([\w-]+\)$/i,
+
 //  , \t, \r, \n
 re.whiteSpaces = /\s+/g,
 re.whiteSpacesAfterSymbol = /([(,:])\s/g,

--- a/test/expected/issue70.css
+++ b/test/expected/issue70.css
@@ -1,0 +1,1 @@
+:root{--foo:"Foo"}.foo{font-family:var(--foo)}.bar{font-family:Bar,var(--foo),serif}.baz{font-family:"var(--foo)"}

--- a/test/fixtures/issue70.css
+++ b/test/fixtures/issue70.css
@@ -1,0 +1,15 @@
+:root {
+  --foo: "Foo";
+}
+
+.foo {
+  font-family: var(--foo);
+}
+
+.bar {
+  font-family: Bar, var(--foo), serif;
+}
+
+.baz {
+  font-family: "var(--foo)";
+}


### PR DESCRIPTION
The `var()` function of a custom properties should be untouched.

This fixes #70.