### PR TITLE
Use shortest unit for zero value

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ var onecolor = require("onecolor");
 var pkg = require("./package.json");
 var postcss = require("postcss");
 var re = require("./lib/regexp");
+var unit = require("./lib/unit");
 
 // Check comment is a source map annotation or not
 var isSourceMapAnnotation = function (comment) {
@@ -105,7 +106,7 @@ var toShortestColor = function (m, leading, r1, r2, g1, g2, b1, b2) {
 };
 
 // Remove unit from 0 length and 0 percentage if possible
-var removeUnitOfZero = function (prop, m, leading, num, unit, position, value) {
+var removeUnitOfZero = function (prop, m, leading, num, u, position, value) {
   if (
     prop === "flex" ||
     prop === "-ms-flex" ||
@@ -115,6 +116,10 @@ var removeUnitOfZero = function (prop, m, leading, num, unit, position, value) {
     value.indexOf("calc(") !== -1
   ) {
     return m;
+  }
+
+  if (unit.forZero.hasOwnProperty(u)) {
+    num += unit.forZero[u];
   }
 
   return leading + num;
@@ -566,7 +571,7 @@ var wringAtRule = function (atRule) {
     params = params.replace(re.quotedString, "$2");
   }
 
-  if (atRule.name === "supports") {
+  if (atRule.name === "media" || atRule.name === "supports") {
     params = params.replace(re.declInParentheses, wringDeclLike);
   }
 

--- a/index.js
+++ b/index.js
@@ -571,7 +571,7 @@ var wringAtRule = function (atRule) {
     params = params.replace(re.quotedString, "$2");
   }
 
-  if (atRule.name === "media" || atRule.name === "supports") {
+  if (atRule.name === "supports") {
     params = params.replace(re.declInParentheses, wringDeclLike);
   }
 

--- a/lib/regexp.js
+++ b/lib/regexp.js
@@ -86,5 +86,6 @@ re.whiteSpacesAfterSymbol = /([(,:])\s/g;
 re.whiteSpacesBeforeSymbol = /\s([),:])/g;
 re.whiteSpacesBothEndsOfSymbol = /\s([*/])\s/g;
 
-// 0%, 0em, 0ex, 0ch, 0rem, 0vw, 0vh, 0vmin, 0vmax, 0cm, 0mm, 0in, 0pt, 0pc, 0px
-re.zeroValueUnit = /(^|\s|\(|,)(0)(%|em|ex|ch|rem|vw|vh|vmin|vmax|cm|mm|in|pt|pc|px|s|ms|deg|grad|rad|turn|Hz|kHz|dpi|dpcm|dppx)/gi;
+// 0%, 0ch, 0cm, 0deg, 0dpcm, 0dpi, 0dppx, 0em, 0ex, 0grad, 0Hz, 0in, 0kHz, 0mm,
+// 0ms, 0pc, 0pt, 0px, 0rad, 0rem, 0s, 0turn, 0vh, 0vmax, 0vmin, 0vw
+re.zeroValueUnit = /(^|\s|\(|,)(0)(%|ch|cm|deg|dpcm|dpi|dppx|em|ex|grad|Hz|in|kHz|mm|ms|pc|pt|px|rad|rem|s|turn|vh|vmax|vmin|vw)/gi;

--- a/lib/regexp.js
+++ b/lib/regexp.js
@@ -87,4 +87,4 @@ re.whiteSpacesBeforeSymbol = /\s([),:])/g;
 re.whiteSpacesBothEndsOfSymbol = /\s([*/])\s/g;
 
 // 0%, 0em, 0ex, 0ch, 0rem, 0vw, 0vh, 0vmin, 0vmax, 0cm, 0mm, 0in, 0pt, 0pc, 0px
-re.zeroValueUnit = /(^|\s|\(|,)(0)(%|em|ex|ch|rem|vw|vh|vmin|vmax|cm|mm|in|pt|pc|px)/gi;
+re.zeroValueUnit = /(^|\s|\(|,)(0)(%|em|ex|ch|rem|vw|vh|vmin|vmax|cm|mm|in|pt|pc|px|s|ms|deg|grad|rad|turn|Hz|kHz|dpi|dpcm|dppx)/gi;

--- a/lib/unit.js
+++ b/lib/unit.js
@@ -1,0 +1,17 @@
+"use strict";
+
+var unit = exports;
+
+unit.forZero = {
+  "deg": "deg",
+  "dpcm": "dpi",
+  "dpi": "dpi",
+  "dppx": "dpi",
+  "grad": "deg",
+  "Hz": "Hz",
+  "kHz": "Hz",
+  "ms": "s",
+  "rad": "deg",
+  "s": "s",
+  "turn": "deg"
+};

--- a/test/expected/issue11.css
+++ b/test/expected/issue11.css
@@ -1,1 +1,1 @@
-.foo{transition:0s;transition:0ms}
+.foo{transition:0s}

--- a/test/expected/zero-value-unit.css
+++ b/test/expected/zero-value-unit.css
@@ -1,1 +1,1 @@
-.foo{border:0 solid red}
+.foo{border:0 solid red}@media(min-resolution:0dpi){.bar{pitch:0Hz;transform:rotate(0deg);transition-duration:0s}}

--- a/test/expected/zero-value-unit.css
+++ b/test/expected/zero-value-unit.css
@@ -1,1 +1,1 @@
-.foo{border:0 solid red}@media(min-resolution:0dpi){.bar{pitch:0Hz;transform:rotate(0deg);transition-duration:0s}}
+.foo{border:0 solid red}.bar{pitch:0Hz;transform:rotate(0deg);transition-duration:0s}

--- a/test/fixtures/zero-value-unit.css
+++ b/test/fixtures/zero-value-unit.css
@@ -1,3 +1,11 @@
 .foo {
   border: 0px solid red;
 }
+
+@media (min-resolution: 0dppx) {
+  .bar {
+    pitch: 0kHz;
+    transform: rotate(0grad);
+    transition-duration: 0ms;
+  }
+}

--- a/test/fixtures/zero-value-unit.css
+++ b/test/fixtures/zero-value-unit.css
@@ -2,10 +2,8 @@
   border: 0px solid red;
 }
 
-@media (min-resolution: 0dppx) {
-  .bar {
-    pitch: 0kHz;
-    transform: rotate(0grad);
-    transition-duration: 0ms;
-  }
+.bar {
+  pitch: 0kHz;
+  transform: rotate(0grad);
+  transition-duration: 0ms;
 }


### PR DESCRIPTION
Some unit (e.g. `ms`) cannot be omitted even if its value is `0`. However it can be converted to shorter unit (e.g. `s`).

- `0ms` to `0s`
- `0grad` and `0turn` to `0deg`
- `0kHz` to `0Hz`
- `0dpcm` and `0dppx` to `0dpi`