### PR TITLE
Use shortest time unit

### DIFF
--- a/index.js
+++ b/index.js
@@ -125,6 +125,11 @@ var removeUnitOfZero = function (prop, m, leading, num, u, position, value) {
   return leading + num;
 };
 
+// Convert to shortest time
+var toShortestTime = function (m, leading, n) {
+  return leading + (parseInt(n) / 100).toString().replace(/^0+/, "") + "s";
+};
+
 // Unquote inside `url()` notation if possible
 var unquoteURL = function (m, leading, url) {
   var quote;
@@ -175,6 +180,9 @@ var wringValue = function (prop, value) {
   ).replace(
     re.decimalWithZeros,
     "$1$2$3.$4"
+  ).replace(
+    re.timeEndsWithZero,
+    toShortestTime
   ).replace(
     re.urlFunction,
     unquoteURL

--- a/lib/regexp.js
+++ b/lib/regexp.js
@@ -65,6 +65,9 @@ re.semicolons = /;/g;
 // ident-ifi-ers
 re.sequenceOfIdentifiers = /^[\w-]+$/;
 
+// 3210ms
+re.timeEndsWithZero = /(^|\s|\(|,)(\d{2,})0ms/gi;
+
 // u0-10ffff, u000000-10ffff
 re.unicodeRangeDefault = /u\+0{1,6}-10ffff/i;
 

--- a/test/expected/time.css
+++ b/test/expected/time.css
@@ -1,0 +1,1 @@
+.foo{pause-after:.21s;pause-before:2.1s;pause:4321ms}

--- a/test/fixtures/time.css
+++ b/test/fixtures/time.css
@@ -1,0 +1,5 @@
+.foo {
+  pause-after: 210ms;
+  pause-before: 2100ms;
+  pause: 4321ms;
+}


### PR DESCRIPTION
If `ms` value ends with `0`, it should be converted to `s` value. In other words, `.21s` is shorter than `210ms`, and `3.21s` is shorter than `3210ms`. 