### PR TITLE
Remove unnecessary universal selectors

### DIFF
--- a/index.js
+++ b/index.js
@@ -257,6 +257,9 @@ var wringSelector = function (selector) {
   ).replace(
     re.selectorPseudoElements,
     "$1"
+  ).replace(
+    re.selectorVerboseUniversal,
+    "$1"
   );
 };
 

--- a/lib/regexp.js
+++ b/lib/regexp.js
@@ -65,6 +65,9 @@ re.selectorNegationFunction = /:not\((([^()]*(\([^()]*\))?)*)\)/gi;
 // ::before, ::after, ::first-line, ::first-letter
 re.selectorPseudoElements = /(:)\1(?=after|before|first-(letter|line))/g;
 
+// *#foo, *.bar, *:link, *[baz]
+re.selectorVerboseUniversal = /\*([#.:[])/g;
+
 // ;
 re.semicolons = /;/g;
 

--- a/test/expected/selector-universal.css
+++ b/test/expected/selector-universal.css
@@ -1,0 +1,1 @@
+.foo,.foo .foo,#bar,#bar #bar,[baz],[baz] [baz],:link{color:red}

--- a/test/fixtures/selector-universal.css
+++ b/test/fixtures/selector-universal.css
@@ -1,0 +1,9 @@
+*.foo,
+.foo *.foo,
+*#bar,
+#bar *#bar,
+*[baz],
+[baz] *[baz],
+*:link {
+  color: red;
+}


### PR DESCRIPTION
- `*#foo` to `#foo`
- `*.bar` to `.bar`
- `*:link` to `:link`
- `*[baz]` to `[baz]`

See also: https://www.w3.org/TR/CSS2/selector.html#universal-selector