### PR TITLE
Plus sign (+) in selector failed

### DIFF
--- a/test/expected/selector-combinator.css
+++ b/test/expected/selector-combinator.css
@@ -1,1 +1,1 @@
-.foo>.bar{display:block}.foo+.baz{display:block}.foo~.qux{display:block}.foo .\<quux\>{display:block}
+.foo>.bar{display:block}.foo+.baz{display:block}.foo~.qux{display:block}.foo .\<quux\>{display:block}.foo\+ .bar{display:block}.foo\++.baz{display:block}

--- a/test/fixtures/selector-combinator.css
+++ b/test/fixtures/selector-combinator.css
@@ -13,3 +13,11 @@
 .foo .\<quux\> {
   display: block;
 }
+
+.foo\+ .bar {
+  display: block;
+}
+
+.foo\+ + .baz {
+  display: block;
+}


### PR DESCRIPTION
When using a combinator as part of the class name, minifier fails.
This PR adds a failure test.

Related: iamvdo/pleeease#80