### PR TITLE
Preserve white spaces around escaped combinators

### DIFF
--- a/index.js
+++ b/index.js
@@ -237,6 +237,15 @@ var trimNegationFunction = function (m, not) {
   return ":not(" + not.trim() + ")";
 };
 
+// Remove white spaces around `>`, `+`, and `~`, but not `\>`, `\+`, and `\~`
+var trimSelectorCombinator = function (m, combinator, backslash) {
+  if (backslash) {
+    return " " + combinator + " ";
+  }
+
+  return combinator;
+};
+
 // Wring selector of ruleset
 var wringSelector = function (selector) {
   return selector.replace(
@@ -253,7 +262,7 @@ var wringSelector = function (selector) {
     trimNegationFunction
   ).replace(
     re.selectorCombinators,
-    "$1"
+    trimSelectorCombinator
   ).replace(
     re.selectorPseudoElements,
     "$1"

--- a/lib/regexp.js
+++ b/lib/regexp.js
@@ -54,7 +54,7 @@ re.quotedString = /("|')?(.*)\1/;
 re.selectorAtt = /\[\s*(.*?)(?:\s*([~|^$*]?=)\s*(("|').*\4|.*?[^\\]))?\s*\]/g;
 
 // p > a, p + a, p ~ a
-re.selectorCombinators = /\s*(\\?[>+~])\s*/g;
+re.selectorCombinators = /\s+((\\?)[>+~])\s+/g;
 
 // :lang(ja), :nth-child(0), nth-last-child(0), nth-of-type(1n), nth-last-of-type(1n)
 re.selectorFunctions = /:(lang|nth-(?:last-)?(?:child|of-type))\((.*?[^\\])\)/gi;

--- a/test/expected/selector-combinator.css
+++ b/test/expected/selector-combinator.css
@@ -1,1 +1,1 @@
-.foo>.bar{display:block}.foo+.baz{display:block}.foo~.qux{display:block}.foo .\<quux\>{display:block}
+.foo>.bar{display:block}.foo+.baz{display:block}.foo~.qux{display:block}.foo .\<quux\>{display:block}.foo\+ .bar{display:block}.foo\++.baz{display:block}

--- a/test/fixtures/selector-combinator.css
+++ b/test/fixtures/selector-combinator.css
@@ -13,3 +13,11 @@
 .foo .\<quux\> {
   display: block;
 }
+
+.foo\+ .bar {
+  display: block;
+}
+
+.foo\+ + .baz {
+  display: block;
+}


### PR DESCRIPTION
If white spaces around `\>`, `\+`, and `\~` in descendant combinator are
removed, this selector may transform into the sequence of selectors.
This will broke selector completely. These should be preserved.

This resolves #83.