### PR TITLE
Don’t remove unit of 0 from custom property value

### DIFF
--- a/index.js
+++ b/index.js
@@ -110,7 +110,8 @@ function removeUnitOfZero(prop, m, leading, num, u, position, value) {
     prop === "-webkit-flex" ||
     prop === "flex-basis" ||
     prop === "-webkit-flex-basis" ||
-    value.indexOf("calc(") !== -1
+    value.indexOf("calc(") !== -1 ||
+    prop.startsWith("--")
   ) {
     return m;
   }

--- a/test/expected/issue85.css
+++ b/test/expected/issue85.css
@@ -1,0 +1,1 @@
+:root{--foo:0px}.foo{top:calc(var(--foo))}

--- a/test/fixtures/issue85.css
+++ b/test/fixtures/issue85.css
@@ -1,0 +1,7 @@
+:root {
+  --foo: 0px;
+}
+
+.foo {
+  top: calc(var(--foo));
+}


### PR DESCRIPTION
A custom property may be used in `calc()`. And, if `0` appears in
`calc()` in add or sub, `calc()` always returns `0`. So, a custom
property value must have a unit.

This fixes #85.