### PR TITLE
Support in-casesensitivity flag in attr selector

### DIFF
--- a/index.js
+++ b/index.js
@@ -193,11 +193,15 @@ function unquoteAttributeSelector(m, att, con, val, oq, flag) {
     val = `${quote}${val}${quote}`;
   }
 
-  if (flag === "i") {
-    val = `${val} i`;
+  if (!flag) {
+    flag = "";
   }
 
-  return `[${att}${con}${val}]`;
+  if (flag && !val.startsWith(quote)) {
+    flag = ` ${flag}`;
+  }
+
+  return `[${att}${con}${val}${flag}]`;
 }
 
 // Remove white spaces from string

--- a/index.js
+++ b/index.js
@@ -181,7 +181,7 @@ function wringValue(prop, value) {
 }
 
 // Unquote attribute selector if possible
-function unquoteAttributeSelector(m, att, con, val) {
+function unquoteAttributeSelector(m, att, con, val, oq, flag) {
   if (!con || !val) {
     return `[${att}]`;
   }
@@ -191,6 +191,10 @@ function unquoteAttributeSelector(m, att, con, val) {
 
   if (!canUnquote(val)) {
     val = `${quote}${val}${quote}`;
+  }
+
+  if (flag === "i") {
+    val = `${val} i`;
   }
 
   return `[${att}${con}${val}]`;

--- a/lib/regexp.js
+++ b/lib/regexp.js
@@ -51,7 +51,7 @@ re.propertyMultipleValues = /^(margin|padding|border-(color|radius|spacing|style
 re.quotedString = /("|')?(.*)\1/;
 
 // [class = "foo"], [class ~= "foo"], [class |= "foo"], [class ^= "foo"], [class $= "foo"], [class *= "foo"]
-re.selectorAtt = /\[\s*(.*?)(?:\s*([~|^$*]?=)\s*(("|').*\4|.*?[^\\]))?\s*\]/g;
+re.selectorAtt = /\[\s*(.*?)(?:\s*([~|^$*]?=)\s*(("|').*\4|.*?[^\\]))?\s*(i)?\]/g;
 
 // p > a, p + a, p ~ a
 re.selectorCombinators = /\s+((\\?)[>+~])\s+/g;

--- a/test/expected/issue87.css
+++ b/test/expected/issue87.css
@@ -1,1 +1,1 @@
-[class=foo i]{display:block}[class="bar baz" i]{display:block}
+[class=foo i]{display:block}[class="bar baz"i]{display:block}

--- a/test/expected/issue87.css
+++ b/test/expected/issue87.css
@@ -1,0 +1,1 @@
+[class=foo i]{display:block}[class="bar baz" i]{display:block}

--- a/test/fixtures/issue87.css
+++ b/test/fixtures/issue87.css
@@ -1,0 +1,8 @@
+[class = "foo" i] {
+  display: block;
+}
+
+[class = "bar baz"
+i] {
+  display: block;
+}


### PR DESCRIPTION
This type of selector already is supported by Firefox 47+, Chrome 49+,
and Safari 9.

This fixes #87.